### PR TITLE
Fix problem installing gem using JRuby

### DIFF
--- a/gem/visibilityjs.gemspec
+++ b/gem/visibilityjs.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Andrey "A.I" Sitnik']
   s.email       = ['andrey@sitnik.ru']
   s.homepage    = 'https://github.com/ai/visibility.js'
-  s.summary     = 'Visibility.js – a wrapper for the Page Visibility API.'
+  s.summary     = 'Visibility.js - a wrapper for the Page Visibility API.'
   s.description = 'Visibility.js allow you to determine whether ' +
                   'your web page is visible to an user, is hidden in ' +
                   'background tab or is prerendering. It allows you use ' +


### PR DESCRIPTION
Hi, I was getting the following error trying to install visibility.js using JRuby 1.6.2. This is fixed by the attached commits.

```
$ gem install -V visibilityjs -v '0.4.3'
GET http://gems.rubyforge.org/specs.4.8.gz
302 Found
GET http://production.s3.rubygems.org/specs.4.8.gz
304 Not Modified
GET http://gems.github.com/specs.4.8.gz
304 Not Modified
GET http://gems.rubyforge.org/latest_specs.4.8.gz
302 Found
GET http://production.s3.rubygems.org/latest_specs.4.8.gz
304 Not Modified
GET http://gems.github.com/latest_specs.4.8.gz
304 Not Modified
Installing gem visibilityjs-0.4.3
StreamReader.java:98:in `checkPrintable': unacceptable character '' (0x80) special characters are not allowed
in "<reader>", position 156
    from StreamReader.java:191:in `update'
    from StreamReader.java:63:in `<init>'
    from PsychParser.java:101:in `parse'
    from PsychParser$i$1$0$parse.gen:65535:in `call'
        <<SNIP>>
    from /Users/user/.rvm/rubies/jruby-1.6.2/bin/gem:25:in `chained_0_rescue_1$RUBY$SYNTHETIC__file__'
    from /Users/user/.rvm/rubies/jruby-1.6.2/bin/gem:24:in `__file__'
    from /Users/user/.rvm/rubies/jruby-1.6.2/bin/gem:-1:in `load'
    from Ruby.java:671:in `runScript'
    from Ruby.java:575:in `runNormally'
    from Ruby.java:424:in `runFromMain'
    from Main.java:278:in `doRunFromMain'
    from Main.java:198:in `internalRun'
    from Main.java:164:in `run'
    from Main.java:148:in `run'
    from Main.java:128:in `main'
$
```
