### PR TITLE
Fix Rails integration

### DIFF
--- a/lib/visibilityjs.rb
+++ b/lib/visibilityjs.rb
@@ -1,16 +1,19 @@
 # Used only for Ruby on Rails gem to tell, that gem contain `lib/assets` with
 # visibility.js file.
+
 module VisibilityJs
 
-  def self.install(sprockets)
-    sprockets.append_path(Pathname(__FILE__).dirname)
+  # Path where is the visibility.js located.
+  def self.assets_path
+    Pathname(__FILE__).dirname
   end
 
-  module Rails
-    class Engine < ::Rails::Engine
-      initializer 'visibilityjs' do |app|
-        VisibilityJs.install(app.config.assets)
-      end
-    end
+  # Add assets path to standalone Sprockets environment.
+  def self.install(sprockets)
+    sprockets.append_path(assets_path)
   end
+end
+
+if defined?(Rails)
+  require 'visibilityjs/railtie'
 end

--- a/lib/visibilityjs/railtie.rb
+++ b/lib/visibilityjs/railtie.rb
@@ -1,0 +1,7 @@
+# Add visibility.js path to the Rails assets paths.
+
+module VisibilityJs
+  class Railtie < Rails::Railtie
+    config.assets.configure { |env| VisibilityJs.install(env) }
+  end
+end

--- a/visibilityjs.gemspec
+++ b/visibilityjs.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
                         'lib/visibility.timers.js',
                         'lib/visibility.fallback.js',
                         'lib/visibilityjs.rb',
+                        'lib/visibilityjs/railtie.rb',
                         'LICENSE', 'README.md', 'ChangeLog.md']
   s.extra_rdoc_files = ['LICENSE', 'README.md', 'ChangeLog.md']
   s.require_path     = 'lib'


### PR DESCRIPTION
#### Synopsis
It was broken in #19 
```
$ rake assets:precompile
rake aborted!
Sprockets::FileNotFound: couldn't find file 'visibility' with type 'application/javascript'
```
#### What's done
1) fix loading in Rails
2) fix loading in non-Rails environments (`NameError: uninitialized constant Rails`)
3) load using railtie instead of engine