### PR TITLE
Add NPM install section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,14 @@ Visibility.js is available by Bower package manager:
 bower install --save visibilityjs
 ```
 
+### NPM
+
+Available by [NPM](https://www.npmjs.com/package/visibilityjs):
+
+```
+npm install --save visibilityjs
+```
+
 ### Ruby on Rails
 
 For Ruby on Rails you can use gem for Assets Pipeline.


### PR DESCRIPTION
NPM module wasn't mentioned in readme. This fixes that.