### PR TITLE
Adapt module export for Typescript 2.6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'visibilityjs' {
-    export default new Visibility();
+    const _default: Visibility;
+    export default _default;
 
     class Visibility {
         every(interval: number, callback: Function);


### PR DESCRIPTION
As per https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts, the current index.d.ts causes error when using Typescript 2.6 + .