### PR TITLE
types: add return type to "unbind" method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module 'visibilityjs' {
     export function isSupported(): boolean;
     export function state(): string;
     export function hidden(): boolean;
-    export function unbind(id: number);
+    export function unbind(id: number): void;
     export function change(listener: VisiblityChangeListener): number|boolean;
     export function stop(id: number): boolean;
 


### PR DESCRIPTION
Fixes the `'unbind', which lacks return-type annotation, implicitly has an 'any' return type.` error thrown when using `noImplicitAny`